### PR TITLE
fix : pet 코틀린 2차 변환

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
     id("org.springframework.boot") version "3.5.3"
     id("io.spring.dependency-management") version "1.1.7"
 
-    //코틀린 설정
-    kotlin("jvm") version "1.9.23"
-    kotlin("plugin.spring") version "1.9.23"
-    kotlin("plugin.jpa") version "1.9.23"
 }
 
 group = "com"
@@ -66,16 +62,13 @@ dependencies {
     // WebSocket
     implementation ("org.springframework.boot:spring-boot-starter-websocket")
 
-<<<<<<< HEAD
     // Kotlin dependencies
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-=======
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test")
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
->>>>>>> origin/develop
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/back/domain/notification/entity/Notification.kt
+++ b/backend/src/main/java/com/back/domain/notification/entity/Notification.kt
@@ -16,22 +16,22 @@ class Notification private constructor(
     @field:Enumerated(EnumType.STRING)
     @field:Column(name = "notification_type", nullable = false)
     var type: NotificationType,
-    
+
     @field:Column(name = "notification_title", nullable = false)
     var title: String,
-    
+
     @field:Column(name = "notification_message", nullable = false)
     @field:Lob
     var message: String,
-    
+
     @field:ManyToOne(fetch = FetchType.LAZY)
     @field:JoinColumn(name = "member_id", nullable = false)
     var member: Member,
-    
+
     @field:ManyToOne(fetch = FetchType.LAZY)
     @field:JoinColumn(name = "adoption_id")
     var adoption: Adoption?,
-    
+
     @field:ManyToOne(fetch = FetchType.LAZY)
     @field:JoinColumn(name = "care_id")
     var care: Care?

--- a/backend/src/main/java/com/back/domain/pet/dto/request/PetCreateRequestDto.kt
+++ b/backend/src/main/java/com/back/domain/pet/dto/request/PetCreateRequestDto.kt
@@ -7,16 +7,16 @@ import jakarta.validation.constraints.NotNull
 
 data class PetCreateRequestDto(
     @field:NotBlank(message = "이름은 필수입니다.")
-    val name: String,
+    val name: String ="",
 
     @field:NotBlank(message = "품종은 필수입니다.")
-    val species: String,
+    val species: String ="",
 
     @field:Min(value = 0, message = "나이는 0 이상이어야 합니다.")
-    val age: Int,
+    val age: Int =0 ,
 
     @field:NotNull(message = "성별은 필수입니다.")
-    val gender: Gender,
+    val gender: Gender= Gender.MALE,
 
     val description: String? = null,
     val imageUrl: String? = null,

--- a/backend/src/main/java/com/back/domain/pet/dto/request/PetUpdateRequestDto.kt
+++ b/backend/src/main/java/com/back/domain/pet/dto/request/PetUpdateRequestDto.kt
@@ -1,25 +1,14 @@
 package com.back.domain.pet.dto.request
 
 import com.back.domain.pet.enums.Gender
-import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 
 data class PetUpdateRequestDto(
-    @field:NotBlank(message = "이름은 필수입니다.")
-    var name: String,
-
-    @field:NotBlank(message = "품종은 필수입니다.")
-    var species: String,
-
-    @field:Min(value = 0, message = "나이는 0 이상이어야 합니다.")
-    var age: Int = 0,
-
-    @field:NotNull(message = "성별은 필수입니다.")
-    var gender: Gender,
-
+    var name: String? = null,
+    var species: String? = null,
+    var age: Int? = null,
+    var gender: Gender? = null,
     var description: String? = null,
     var imageUrl: String? = null,
     var shelterName: String? = null,
-    var statuses: List<String> = emptyList()
+    var statuses: List<String>? = null
 )

--- a/backend/src/main/java/com/back/domain/pet/entity/Pet.kt
+++ b/backend/src/main/java/com/back/domain/pet/entity/Pet.kt
@@ -44,10 +44,11 @@ class Pet protected constructor(
     @JoinColumn(name = "shelter_id", nullable = true)
     var shelter: Shelter? = null,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    var member: Member? = null
 ) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    lateinit var member: Member
+
     @CreatedDate
     @Column(updatable = false)
     var createdAt: LocalDateTime? = null
@@ -64,12 +65,12 @@ class Pet protected constructor(
 
 
     fun updatePet(dto: PetUpdateRequestDto) {
-        this.name = dto.name
-        this.species = dto.species
-        this.age = dto.age
-        this.gender = dto.gender
-        this.description = dto.description
-        this.imageUrl = dto.imageUrl
+        dto.name?.let { this.name = it }
+        dto.species?.let { this.species = it }
+        dto.age?.let { this.age = it }
+        dto.gender?.let { this.gender = it }
+        dto.description?.let { this.description = it }
+        dto.imageUrl?.let { this.imageUrl = it }
     }
     companion object {
         fun create(
@@ -80,7 +81,7 @@ class Pet protected constructor(
             description: String? = null,
             imageUrl: String? = null,
             shelter: Shelter? = null,
-            member: Member? = null,
+            member: Member,
             statuses: List<PetStatus> = emptyList()
         ): Pet {
             val pet = Pet(
@@ -91,8 +92,8 @@ class Pet protected constructor(
                 description = description,
                 imageUrl = imageUrl,
                 shelter = shelter,
-                member = member
             )
+            pet.member = member
             pet.petStatuses = statuses.toMutableList()
             return pet
         }

--- a/backend/src/test/java/com/back/domain/pet/controller/PetControllerTest.kt
+++ b/backend/src/test/java/com/back/domain/pet/controller/PetControllerTest.kt
@@ -47,7 +47,7 @@ class PetControllerTest @Autowired constructor(
         memberRepository.deleteAll()
 
         testMember = Member(
-            email = "testuser@example.com",
+            _email = "testuser@example.com",
             name = "테스트 유저",
             _password = "encoded-password",
             phone = "010-1234-5678",
@@ -56,7 +56,7 @@ class PetControllerTest @Autowired constructor(
         memberRepository.save(testMember)
 
         otherMember = Member(
-            email = "otheruser@example.com",
+            _email = "otheruser@example.com",
             name = "다른 유저",
             _password = "encoded-password",
             phone = "010-9876-5432",

--- a/backend/src/test/java/com/back/domain/pet/controller/PetControllerTest.kt
+++ b/backend/src/test/java/com/back/domain/pet/controller/PetControllerTest.kt
@@ -4,14 +4,11 @@ import com.back.domain.member.entity.Member
 import com.back.domain.member.enums.UserRole
 import com.back.domain.member.repository.MemberRepository
 import com.back.domain.pet.dto.request.PetCreateRequestDto
-import com.back.domain.pet.dto.request.PetUpdateRequestDto
 import com.back.domain.pet.enums.Gender
 import com.back.domain.pet.repository.PetRepository
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.hamcrest.Matchers.containsInAnyOrder
-import org.hamcrest.Matchers.greaterThan
 import org.hamcrest.Matchers.hasSize
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -22,8 +19,9 @@ import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
 
 @ActiveProfiles("test")
@@ -37,7 +35,7 @@ class PetControllerTest @Autowired constructor(
     val memberRepository: MemberRepository
 ) {
 
-    lateinit var testMember: Member
+    lateinit var testMember:  Member
     lateinit var otherMember: Member
 
     @BeforeEach
@@ -48,7 +46,7 @@ class PetControllerTest @Autowired constructor(
         testMember = Member(
             email = "testuser@example.com",
             name = "테스트 유저",
-            password = "encoded-password",
+            _password = "encoded-password",
             phone = "010-1234-5678",
             role = UserRole.USER
         )
@@ -57,7 +55,7 @@ class PetControllerTest @Autowired constructor(
         otherMember = Member(
             email = "otheruser@example.com",
             name = "다른 유저",
-            password = "encoded-password",
+            _password = "encoded-password",
             phone = "010-9876-5432",
             role = UserRole.USER
         )

--- a/backend/src/test/java/com/back/domain/pet/controller/PetControllerTest.kt
+++ b/backend/src/test/java/com/back/domain/pet/controller/PetControllerTest.kt
@@ -4,6 +4,8 @@ import com.back.domain.member.entity.Member
 import com.back.domain.member.enums.UserRole
 import com.back.domain.member.repository.MemberRepository
 import com.back.domain.pet.dto.request.PetCreateRequestDto
+import com.back.domain.pet.dto.request.PetUpdateRequestDto
+import com.back.domain.pet.entity.Pet
 import com.back.domain.pet.enums.Gender
 import com.back.domain.pet.repository.PetRepository
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -19,10 +21,11 @@ import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
+import kotlin.test.assertFalse
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -35,7 +38,7 @@ class PetControllerTest @Autowired constructor(
     val memberRepository: MemberRepository
 ) {
 
-    lateinit var testMember:  Member
+    lateinit var testMember: Member
     lateinit var otherMember: Member
 
     @BeforeEach
@@ -122,5 +125,229 @@ class PetControllerTest @Autowired constructor(
             .andExpect(jsonPath("$.content").isEmpty)
     }
 
-    // 나머지 테스트도 동일하게 변환 가능
+    @Test
+    @WithMockUser(username = "testuser@example.com")
+    @DisplayName("펫 수정 성공 테스트")
+    fun `t3 - update pet success`() {
+        val pet = Pet.create(
+            name = "초코",
+            species = "푸들",
+            age = 3,
+            gender = Gender.FEMALE,
+            description = "활발한 강아지",
+            imageUrl = "http://example.com/image.jpg",
+            member = testMember
+        )
+        petRepository.save(pet)
+
+        val updateDto = PetUpdateRequestDto(
+            name = "초코-수정",
+            species = "푸들",
+            age = 4,
+            gender = Gender.FEMALE,
+            description = "더 활발해진 강아지",
+            imageUrl = "http://example.com/newimage.jpg",
+            shelterName = "",
+            statuses = listOf("ADOPTED", "CARE_IN_PROGRESS")
+        )
+
+        mockMvc.perform(
+            put("/api/pets/${pet.id}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDto))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.content.name").value("초코-수정"))
+            .andExpect(jsonPath("$.content.age").value(4))
+            .andExpect(jsonPath("$.content.description").value("더 활발해진 강아지"))
+            .andExpect(jsonPath("$.content.imageUrl").value("http://example.com/newimage.jpg"))
+            .andExpect(jsonPath("$.content.shelterName").value("보호소 정보 없음"))
+    }
+
+    @Test
+    @WithMockUser(username = "testuser@example.com")
+    @DisplayName("펫 수정 실패 - 존재하지 않는 펫 ID")
+    fun `t4 - update pet fail not found`() {
+        val updateDto = PetUpdateRequestDto(
+            name = "초코-수정",
+            species = "푸들",
+            age = 4,
+            gender = Gender.FEMALE,
+            description = "더 활발해진 강아지",
+            imageUrl = "http://example.com/newimage.jpg",
+            shelterName = "",
+            statuses = listOf("ADOPTED", "CARE_IN_PROGRESS")
+        )
+
+        mockMvc.perform(
+            put("/api/pets/9999")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDto))
+        )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.code").value("PET-404"))
+            .andExpect(jsonPath("$.message").value("해당 동물을 찾을 수 없습니다."))
+    }
+
+    @Test
+    @WithMockUser(username = "otheruser@example.com")
+    @DisplayName("펫 수정 실패 - 권한 없음")
+    fun `t5 - update pet fail forbidden`() {
+        val pet = Pet.create(
+            name = "초코",
+            species = "푸들",
+            age = 3,
+            gender = Gender.FEMALE,
+            description = "활발한 강아지",
+            imageUrl = "http://example.com/image.jpg",
+            member = testMember
+        )
+        petRepository.save(pet)
+
+        val updateDto = PetUpdateRequestDto(
+            name = "수정된 이름",
+            species = "푸들",
+            age = 4,
+            gender = Gender.FEMALE,
+            description = "수정된 설명",
+            imageUrl = "http://example.com/newimage.jpg",
+            shelterName = "",
+            statuses = emptyList()
+        )
+
+        mockMvc.perform(
+            put("/api/pets/${pet.id}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDto))
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("AUTH-403"))
+            .andExpect(jsonPath("$.message").value("권한이 없습니다."))
+    }
+
+    @Test
+    @WithMockUser(username = "testuser@example.com")
+    @DisplayName("펫 삭제 성공 테스트")
+    fun `t7 - delete pet success`() {
+        val pet = Pet.create(
+            name = "초코",
+            species = "푸들",
+            age = 3,
+            gender = Gender.FEMALE,
+            description = "활발한 강아지",
+            imageUrl = "http://example.com/image.jpg",
+            member = testMember
+        )
+        petRepository.save(pet)
+
+        mockMvc.perform(delete("/api/pets/${pet.id}"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+
+        val exists = petRepository.existsById(pet.id!!)
+        assertFalse(exists)
+    }
+
+    @Test
+    @WithMockUser(username = "testuser@example.com")
+    @DisplayName("펫 삭제 실패 - 존재하지 않는 펫 ID")
+    fun `t8 - delete pet fail not found`() {
+        mockMvc.perform(delete("/api/pets/999999"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("PET-404"))
+            .andExpect(jsonPath("$.message").value("해당 동물을 찾을 수 없습니다."))
+    }
+
+    @Test
+    @WithMockUser(username = "otheruser@example.com")
+    @DisplayName("펫 삭제 실패 - 권한 없음")
+    fun `t9 - delete pet fail forbidden`() {
+        val pet = Pet.create(
+            name = "초코",
+            species = "푸들",
+            age = 3,
+            gender = Gender.FEMALE,
+            description = "활발한 강아지",
+            imageUrl = "http://example.com/image.jpg",
+            member = testMember
+        )
+        petRepository.save(pet)
+
+        mockMvc.perform(delete("/api/pets/${pet.id}"))
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("AUTH-403"))
+            .andExpect(jsonPath("$.message").value("권한이 없습니다."))
+    }
+
+    @Test
+    @WithMockUser(username = "testuser@example.com")
+    @DisplayName("펫 단건 조회 성공 테스트")
+    fun `t10 - get pet success`() {
+        val pet = Pet.create(
+            name = "초코",
+            species = "푸들",
+            age = 3,
+            gender = Gender.FEMALE,
+            description = "활발한 강아지",
+            imageUrl = "http://example.com/image.jpg",
+            member = testMember
+        )
+        petRepository.save(pet)
+
+        mockMvc.perform(get("/api/pets/${pet.id}"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.content.name").value("초코"))
+            .andExpect(jsonPath("$.content.species").value("푸들"))
+            .andExpect(jsonPath("$.content.age").value(3))
+            .andExpect(jsonPath("$.content.gender").value("FEMALE"))
+            .andExpect(jsonPath("$.content.description").value("활발한 강아지"))
+            .andExpect(jsonPath("$.content.imageUrl").value("http://example.com/image.jpg"))
+            .andExpect(jsonPath("$.content.shelterName").value("보호소 정보 없음"))
+    }
+
+    @Test
+    @DisplayName("펫 단건 조회 실패 - 없는 ID")
+    fun `t11 - get pet fail not found`() {
+        mockMvc.perform(get("/api/pets/999999"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.code").value("PET-404"))
+    }
+
+    @Test
+    @WithMockUser(username = "testuser@example.com")
+    @DisplayName("펫 전체 조회 성공 테스트")
+    fun `t12 - get all pets`() {
+        val pet1 = Pet.create("초코", "푸들", 3, Gender.FEMALE, "활발한 강아지", "http://example.com/image1.jpg", member = testMember)
+        val pet2 = Pet.create("콩이", "시추", 5, Gender.MALE, "귀여운 강아지", "http://example.com/image2.jpg", member = testMember)
+        petRepository.saveAll(listOf(pet1, pet2))
+
+        mockMvc.perform(get("/api/pets"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.content", hasSize<Any>(2)))
+            .andExpect(jsonPath("$.content[0].name").value("초코"))
+            .andExpect(jsonPath("$.content[1].name").value("콩이"))
+    }
+
+    @Test
+    @DisplayName("펫 전체 조회 - 여러 개")
+    fun `t13 - get pets multiple`() {
+        val pets = listOf(
+            Pet.create("초코", "푸들", 3, Gender.FEMALE, "활발한 강아지", "http://example.com/image1.jpg", member = testMember),
+            Pet.create("콩이", "시추", 5, Gender.MALE, "귀여운 강아지", "http://example.com/image2.jpg", member = testMember),
+            Pet.create("몽이", "말티즈", 2, Gender.FEMALE, "얌전한 강아지", "http://example.com/image3.jpg", member = testMember)
+        )
+        petRepository.saveAll(pets)
+
+        mockMvc.perform(get("/api/pets"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.content", hasSize<Any>(3)))
+            .andExpect(jsonPath("$.content[*].name", containsInAnyOrder("초코", "콩이", "몽이")))
+    }
 }


### PR DESCRIPTION
## 📌 과제 설명
- pet 부분에 코틀린 2차 변환 

## 👩‍💻 요구 사항과 구현 내용 
문제상황
Pet 엔티티에는 name, species, age, gender 같은 필드가 non-null로 정의되어 있음
기존 PetUpdateRequestDto는 @NotBlank나 @NotNull이 붙어있어서 항상 값이 있어야 함
그런데 실제 업데이트 API에서는 부분 업데이트(예: 이름만 바꾸기)를 하고 싶음.
그 상태로 엔티티 updatePet(dto)에서 this.name = dto.name 이런 식으로 바로 넣으면,
DTO가 null일 경우 Type mismatch: inferred type is String? but String was expected 오류 발생.

해결방법
DTO 필드를 nullable로 변경
엔티티 updatePet() 수정

- 기능 동작을 로컬 환경에서 확인하였습니다 

해결하지 못한 것 
- petcontrollerTest 부분 해결 미완료 

## ✅ 피드백 반영사항  

## ✅ PR 포인트 & 궁금한 점 